### PR TITLE
Resolves BASIC-1363 update URL Cutoff settings to 160

### DIFF
--- a/stanford_news.features.field_base.inc
+++ b/stanford_news.features.field_base.inc
@@ -181,7 +181,7 @@ function stanford_news_field_default_field_bases() {
         'target' => 'default',
       ),
       'display' => array(
-        'url_cutoff' => 80,
+        'url_cutoff' => 160,
       ),
       'enable_tokens' => 1,
       'title' => 'optional',


### PR DESCRIPTION
https://stanfordits.atlassian.net/browse/BASIC-1363

Changed the field_s_news_source url cut off for from 80 to 160