### PR TITLE
Removed block titles on banner and banner overlay

### DIFF
--- a/modules/stanford_news_extras/README.md
+++ b/modules/stanford_news_extras/README.md
@@ -1,4 +1,4 @@
-# [Stanford News Extras Importer](https://github.com/SU-SWS/stanford_news)
+# [Stanford News Extras](https://github.com/SU-SWS/stanford_news)
 ##### Version: 7.x-3.2-dev
 
 Stanford News Extras feature provides extra fields needed to support SoE needs.
@@ -11,7 +11,8 @@ Install this module like any other module. [See Drupal Documentation](https://dr
 Configuration
 -------------
 
-Nothing special needed.
+To display properly, this module needs "fullwidth_top" and "highlighted" theme regions. 
+[See Open Framework](https://github.com/SU-SWS/open_framework/blob/8d5f74106fb1708955c9a07a2cd7cedeac117853/open_framework.info).
 
 Troubleshooting
 ---

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -1,0 +1,189 @@
+/* HIDE PAGE TITLE ON NEWS NODES */
+
+.node-type-stanford-news-item #page-title {
+  display: none;
+}
+
+
+/* NEWS BANNER IMAGE STYLES */
+
+.node-type-stanford-news-item .fullwidth .field-name-field-s-news-banner img {
+  width: 100%;
+  height: 300px;
+}
+
+.node-type-stanford-news-item .field-name-field-s-news-banner .field-item {
+  background: #000000;
+}
+
+.node-type-stanford-news-item .field-name-field-s-news-banner img {
+  opacity: .4;
+}
+
+
+/* POSITION AND STYLE NEWS TITLES AND TEASERS OVER BANNER IMAGE - LOGGED OUT */
+
+.node-type-stanford-news-item div#content-head {
+  margin-bottom: 0;
+}
+
+#block-ds-extras-banner-overlay {
+  width: 750px;
+}
+
+#block-ds-extras-banner-overlay .field-name-title h1,
+#block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+  color: white;
+  text-shadow: 0 0 4px black;
+}
+
+#block-ds-extras-banner-overlay {
+  position: absolute;
+  top: 210px;
+}
+
+@media (max-width: 1200px) {
+  #block-ds-extras-banner-overlay {
+    top: 250px;
+  }
+}
+
+@media (max-width: 910px) {
+  #block-ds-extras-banner-overlay {
+    width: 450px;
+    top: 225px;
+  }
+  #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1.4em;
+  }
+  #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 767px) {
+  #block-ds-extras-banner-overlay {
+    position: relative;
+    top: -310px;
+  }
+  .node-type-stanford-news-item div#block-ds-extras-banner-overlay {
+    margin-bottom: -245px;
+  }
+}
+
+@media (max-width: 485px) {
+  #block-ds-extras-banner-overlay {
+    width: 100%;
+  }
+  #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1.2em;
+  }
+  #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 15px;
+  }
+}
+
+@media (max-width: 380px) {
+  #block-ds-extras-banner-overlay {
+    top: -315px;
+    width: 250px;
+  }
+  #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1em;
+  }
+  #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 14px;
+  }
+}
+
+
+/* POSITION AND STYLE NEWS TITLES AND TEASERS OVER BANNER IMAGE - LOGGED IN */
+
+.logged-in #block-ds-extras-banner-overlay {
+  top: 285px;
+}
+
+@media (max-width: 1200px) {
+  .logged-in #block-ds-extras-banner-overlay {
+    top: 325px;
+  }
+}
+
+@media (max-width: 767px) {
+  .logged-in #block-ds-extras-banner-overlay {
+    top: -305px;
+  }
+}
+
+@media (max-width: 485px) {
+  .logged-in #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1.2em;
+  }
+  .logged-in #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 15px;
+  }
+}
+
+@media (max-width: 380px) {
+  .logged-in #block-ds-extras-banner-overlay {
+    top: -325px;
+  }
+}
+
+
+/* STYLE NEWS FEATURED IMAGE CAPTION AND CREDITS */
+
+.node-type-stanford-news-item .content-body .field-name-field-s-image-image {
+  margin-bottom: 0;
+}
+
+.node-type-stanford-news-item .content-body .group-s-news-body-style {
+  margin-top: 1em;
+}
+
+.node-type-stanford-news-item .content-body .field-name-field-s-image-caption,
+.node-type-stanford-news-item .field-name-field-s-image-caption p {
+  margin-bottom: 0;
+}
+
+.node-type-stanford-news-item .caption {
+  font-size: .7em;
+  font-style: normal;
+}
+
+.node-type-stanford-news-item .caption p:after {
+  content: " |";
+  padding-right: 3px;
+}
+
+.node-type-stanford-news-item .credits {
+  margin-bottom: 0;
+  margin-top: -8px;
+  color: #928b81;
+  font-size: .7em;
+}
+
+.node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
+.node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
+  display: inline-block;
+}
+
+@media (max-width: 550px) {
+  .node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
+  .node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
+    display: block;
+  }
+}
+
+
+/* BODY CONTENT STYLES */
+
+.node-type-stanford-news-item .body-style {
+  width: 750px;
+}
+
+@media (max-width: 910px) {
+  .node-type-stanford-news-item .body-style {
+    width: 100%;
+  }
+}

--- a/modules/stanford_news_extras/stanford_news_extras.info
+++ b/modules/stanford_news_extras/stanford_news_extras.info
@@ -66,4 +66,5 @@ features[taxonomy][] = research_themes
 features[taxonomy][] = school_themes
 features[taxonomy][] = stanford_department
 features_exclude[dependencies][stanford_news_extras_importer] = stanford_news_extras_importer
+stylesheets[all][] = css/stanford_news_extras.css
 project status url = https://github.com/SU-SWS/stanford_news.git

--- a/modules/stanford_news_extras/stanford_news_extras.install
+++ b/modules/stanford_news_extras/stanford_news_extras.install
@@ -10,6 +10,9 @@ function stanford_news_extras_install() {
 
   // Set the DS region block values.
   stanford_news_extras_set_ds_region_blocks();
+
+  // Set the context for news extras.
+  stanford_news_extras_set_contexts();
 }
 
 /**
@@ -63,8 +66,9 @@ function stanford_news_extras_set_ds_region_blocks() {
 
   if (!isset($settings['banner'])) {
     $settings['banner'] = array(
-      'title' => '<none>',
+      'title' => 'Banner',
       'info' => 'node_stanford_news_item_stanford_news_extras',
+      'label_display' => 'hidden',
     );
   }
   else {
@@ -74,8 +78,9 @@ function stanford_news_extras_set_ds_region_blocks() {
 
   if (!isset($settings['banner_overlay'])) {
     $settings['banner_overlay'] = array(
-      'title' => '<none>',
+      'title' => 'Banner Overlay',
       'info' => 'node_stanford_news_item_stanford_news_extras',
+      'label_display' => 'hidden',
     );
   }
   else {
@@ -86,3 +91,16 @@ function stanford_news_extras_set_ds_region_blocks() {
 }
 
 
+/**
+ * Set the context for news extras.
+ */
+function stanford_news_extras_set_contexts() {
+
+  $context_status = variable_get('context_status', array());
+
+  // Get the context for news extras.
+  $context_status['stanford_news_extras'] = FALSE;
+
+  variable_set('context_status', $context_status);
+
+}

--- a/modules/stanford_news_extras/stanford_news_extras.install
+++ b/modules/stanford_news_extras/stanford_news_extras.install
@@ -102,5 +102,4 @@ function stanford_news_extras_set_contexts() {
   $context_status['stanford_news_extras'] = FALSE;
 
   variable_set('context_status', $context_status);
-
 }

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -18,7 +18,9 @@ function stanford_news_extras_form_alter(&$form, &$form_state, $form_id) {
   }
 }
 
-
+/**
+ * Implementation of hook_block_view_alter()
+ */
 function stanford_news_extras_block_view_alter(&$data, $block) {
   // Remove title on blocks.
   if ($block->bid == 'ds_extras-banner') {

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -17,3 +17,14 @@ function stanford_news_extras_form_alter(&$form, &$form_state, $form_id) {
       . 'Please keep this title under 70 characters');
   }
 }
+
+
+function stanford_news_extras_block_view_alter(&$data, $block) {
+  // Remove title on blocks.
+  if ($block->bid == 'ds_extras-banner') {
+    $data['title'] = '<none>';
+  }
+  else if ($block->bid == 'ds_extras-banner_overlay') {
+    $data['title'] = '<none>';
+  }
+}


### PR DESCRIPTION
Hey @boznik and @sherakama ,

This functionality doesn't work.
https://github.com/SU-SWS/stanford_news/blob/7.x-3.x-dev/modules/stanford_news_extras/stanford_news_extras.install#L66

 It still keeps the "h2" and looks really weird on the content type edit form.
I have this PR working. Is this approach okay? What do you suggest?

Caryl