### PR TITLE
Fix caption

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,24 +1,130 @@
 engines:
+  # https://docs.codeclimate.com/docs/eslint
+  # ES Linting requires an .eslintrc file to tweak checks.
   eslint:
-    enabled: true
+    enabled: false
   csslint:
     enabled: true
-  phpcodesniffer:
-    enabled: true
-    config:
-      file_extensions: "php,inc,install,module,profile"
-      standard: "Drupal"
-  phpmd:
-    enabled: true
-    config:
-      file_extensions:
-      - inc
-      - module
-      - profile
-      - php
-      - install
+    checks:
+      overqualified-elements:
+        enabled: false
+      order-alphabetical:
+        enabled: false
+      adjoining-classes:
+        enabled: false
+      fallback-colors:
+        enabled: false
+      ids:
+        enabled: false
+      regex-selectors:
+        enabled: false
+  # We don't lint our coffee. Eew.
+  coffeelint:
+    enabled: false
+  # SCSS Lint requires a .scss-lint.yml file in the repo in order to tweak settings.
+  # Withouth the .scss-lint.yml file it will run with the defaults.
+  # Defaults file: https://github.com/brigade/scss-lint/blob/master/config/default.yml
   scss-lint:
     enabled: true
+    checks:
+      IdSelector:
+        enabled: false
+      SelectorFormat:
+        enabled: false
+      NestingDepth:
+        enabled: false
+      MergeableSelector:
+        enabled: false
+      ColorVariable:
+        enabled: false
+      PropertySortOrder:
+        enabled: false
+      SelectorDepth:
+        enabled: false
+      QualifyingElement:
+        enabled: false
+      VendorPrefix:
+        enabled: false
+      LeadingZero:
+        enabled: false
+      HexLength:
+        enabled: false
+      PseudoElement:
+        enabled: false
+  phpcodesniffer:
+    enabled: true
+    checks:
+      Drupal Commenting FunctionComment TypeHintMissing:
+        enabled: false
+      Drupal Commenting FunctionComment IncorrectTypeHint:
+        enabled: false
+      DrupalPractice Commenting CommentEmptyLine SpacingAfter:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName ScopeNotCamelCaps:
+        enabled: false
+      Drupal NamingConventions ValidClassName StartWithCaptial:
+        enabled: false
+      Drupal NamingConventions ValidFunctionName NotCamelCaps:
+        enabled: false
+      DrupalPractice General ClassName ClassPrefix:
+        enabled: false
+      Drupal NamingConventions ValidClassName NoUnderscores:
+        enabled: false
+    config:
+      file_extensions: "php,inc,install,module,profile"
+      standard: "Drupal,DrupalPractice"
+  phpmd:
+    enabled: true
+    checks:
+      Design/WeightedMethodCount:
+        enabled: false
+      CleanCode/StaticAccess:
+        enabled: false
+      CleanCode/ElseExpression:
+        enabled: false
+      CleanCode/BooleanArgumentFlag:
+        enabled: false
+      UnusedFormalParameter:
+        enabled: false
+    config:
+      # https://phpmd.org/rules/index.html
+      # The following sets include everything except the controversial set.
+      # We can configure these further through .xml files. See docs.
+      rulesets: "cleancode,codesize,design,naming,unusedcode"
+      # Include special Drupal file extensions.
+      file_extensions: "inc,module,profile,php,install"
+  # https://docs.codeclimate.com/docs/phan
+  phan:
+    enabled: true
+    config:
+      file_extensions: "php,module,profile,inc,install"
+      # minimum-severity: 1
+      ignore-undeclared: true
+      # quick: true
+      # backward-compatiility-checks: true
+      # dead-code-detection: true
+  # https://docs.codeclimate.com/docs/duplication
+  duplication:
+    enabled: true
+    # exclude_paths:
+    #   - examples/
+    config:
+      languages:
+        javascript:
+          mass_threshold: 50
+          # count_threshold: 3
+        php:
+          mass_threshold: 60
+  fixme:
+    enabled: true
+    config:
+      strings:
+      - FIXME
+      - BUG
+      - TODO
+      - todo
+      - dpm
+      - dsm
 ratings:
   paths:
   - "**.inc"
@@ -26,11 +132,10 @@ ratings:
   - "**.profile"
   - "**.php"
   - "**.install"
-  - "**.css"
   - "**.scss"
   - "**.sass"
   - "**.js"
-##exclude these files/paths
+# exclude these files/paths
 exclude_paths:
 - "**.features.**"
 - "**.views_default.inc"
@@ -41,3 +146,10 @@ exclude_paths:
 - "test/**/*"
 - "**/vendor/**/*"
 - "**.min.*"
+- "tests/"
+- "spec/"
+- "**/vendor/"
+- "**.api.php"
+- "*.twig"
+- "**.tpl.php"
+- "**.strongarm.inc"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,17 +6,19 @@ engines:
   csslint:
     enabled: true
     checks:
-      overqualified-elements:
-        enabled: false
-      order-alphabetical:
-        enabled: false
       adjoining-classes:
         enabled: false
       fallback-colors:
         enabled: false
       ids:
         enabled: false
+      qualified-headings:
+        enabled: false
       regex-selectors:
+        enabled: false
+      order-alphabetical:
+        enabled: false
+      overqualified-elements:
         enabled: false
   # We don't lint our coffee. Eew.
   coffeelint:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,14 +12,16 @@ engines:
         enabled: false
       ids:
         enabled: false
-      qualified-headings:
-        enabled: false
-      regex-selectors:
-        enabled: false
       order-alphabetical:
         enabled: false
       overqualified-elements:
         enabled: false
+      qualified-headings:
+        enabled: false
+      regex-selectors:
+        enabled: false
+      unique-headings:
+         enabled: false
   # We don't lint our coffee. Eew.
   coffeelint:
     enabled: false

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,9 @@
+linters:
+  SingleLinePerSelector:
+    enabled: true
+    exclude:
+      - '**.css'
+  EmptyLineBetweenBlocks:
+    enabled: true
+    exclude:
+      - '**.css'

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -7,8 +7,8 @@
 /* NEWS BANNER IMAGE STYLES */
 
 .node-type-stanford-news-item .fullwidth .field-name-field-s-news-banner img {
-  width: 100%;
   height: 300px;
+  width: 100%;
 }
 
 .node-type-stanford-news-item .field-name-field-s-news-banner .field-item {
@@ -48,8 +48,8 @@
 
 @media (max-width: 910px) {
   #block-ds-extras-banner-overlay {
-    width: 450px;
     top: 225px;
+    width: 450px;
   }
 
   #block-ds-extras-banner-overlay .field-name-title h1 {
@@ -146,10 +146,10 @@
 }
 
 .node-type-stanford-news-item .caption {
+  color: #928b81;
   font-size: .7em;
   font-style: normal;
   line-height: 1.3em;
-  color: #928b81;
 }
 
 .node-type-stanford-news-item .caption p:after {
@@ -157,11 +157,11 @@
 }
 
 .node-type-stanford-news-item .credits {
-  margin-bottom: 0;
-  margin-top: -8px;
   color: #928b81;
   font-size: .7em;
   line-height: 1.3em;
+  margin-bottom: 0;
+  margin-top: -8px;
 }
 
 @media (max-width: 550px) {
@@ -184,16 +184,16 @@
 }
 
 .node-type-stanford-news-item .body-style h2 {
-  margin: 1.3em 0 0.5em;
+  margin: 1.3em 0 .5em;
 }
 
 /* DATE and BYLINE FOR view-mode-stanford_extras_single_region */
 
 .view-mode-stanford_extras_single_region .date-style {
   float: left;
-  margin-bottom: 2px;
-  line-height: 1.2em;
   font-size: 1em;
+  line-height: 1.2em;
+  margin-bottom: 2px;
 }
 
 .view-mode-stanford_extras_single_region .byline-style {

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -141,18 +141,12 @@
     margin-top: 1em;
 }
 
-.node-type-stanford-news-item .content-body .field-name-field-s-image-caption,
-.node-type-stanford-news-item .field-name-field-s-image-caption p {
-    margin-bottom: 0;
-}
-
 .node-type-stanford-news-item .caption {
     font-size: .7em;
     font-style: normal;
 }
 
 .node-type-stanford-news-item .caption p:after {
-    content: " |";
     padding-right: 3px;
 }
 
@@ -161,11 +155,6 @@
     margin-top: -8px;
     color: #928b81;
     font-size: .7em;
-}
-
-.node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
-.node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
-    display: inline-block;
 }
 
 @media (max-width: 550px) {

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -1,220 +1,224 @@
 /* HIDE PAGE TITLE ON NEWS NODES */
 
 .node-type-stanford-news-item #page-title {
-    display: none;
+  display: none;
 }
-
 
 /* NEWS BANNER IMAGE STYLES */
 
 .node-type-stanford-news-item .fullwidth .field-name-field-s-news-banner img {
-    width: 100%;
-    height: 300px;
+  width: 100%;
+  height: 300px;
 }
 
 .node-type-stanford-news-item .field-name-field-s-news-banner .field-item {
-    background: #000000;
+  background: #000000;
 }
 
 .node-type-stanford-news-item .field-name-field-s-news-banner img {
-    opacity: .4;
+  opacity: .4;
 }
-
 
 /* POSITION AND STYLE NEWS TITLES AND TEASERS OVER BANNER IMAGE - LOGGED OUT */
 
 .node-type-stanford-news-item div#content-head {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 #block-ds-extras-banner-overlay {
-    width: 750px;
+  width: 750px;
 }
 
 #block-ds-extras-banner-overlay .field-name-title h1,
 #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
-    color: white;
-    text-shadow: 0 0 4px black;
+  color: white;
+  text-shadow: 0 0 4px black;
 }
 
 #block-ds-extras-banner-overlay {
-    position: absolute;
-    top: 210px;
+  position: absolute;
+  top: 210px;
 }
 
 @media (max-width: 1200px) {
-    #block-ds-extras-banner-overlay {
-        top: 250px;
-    }
+  #block-ds-extras-banner-overlay {
+    top: 250px;
+  }
 }
 
 @media (max-width: 910px) {
-    #block-ds-extras-banner-overlay {
-        width: 450px;
-        top: 225px;
-    }
-    #block-ds-extras-banner-overlay .field-name-title h1 {
-        font-size: 1.4em;
-    }
-    #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
-        font-size: 16px;
-    }
+  #block-ds-extras-banner-overlay {
+    width: 450px;
+    top: 225px;
+  }
+
+  #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1.4em;
+  }
+
+  #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 16px;
+  }
 }
 
 @media (max-width: 767px) {
-    #block-ds-extras-banner-overlay {
-        position: relative;
-        top: -310px;
-    }
-    .node-type-stanford-news-item div#block-ds-extras-banner-overlay {
-        margin-bottom: -245px;
-    }
+  #block-ds-extras-banner-overlay {
+    position: relative;
+    top: -310px;
+  }
+
+  .node-type-stanford-news-item div#block-ds-extras-banner-overlay {
+    margin-bottom: -245px;
+  }
 }
 
 @media (max-width: 485px) {
-    #block-ds-extras-banner-overlay {
-        width: 100%;
-    }
-    #block-ds-extras-banner-overlay .field-name-title h1 {
-        font-size: 1.2em;
-    }
-    #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
-        font-size: 15px;
-    }
+  #block-ds-extras-banner-overlay {
+    width: 100%;
+  }
+
+  #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1.2em;
+  }
+
+  #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 15px;
+  }
 }
 
 @media (max-width: 380px) {
-    #block-ds-extras-banner-overlay {
-        top: -315px;
-        width: 250px;
-    }
-    #block-ds-extras-banner-overlay .field-name-title h1 {
-        font-size: 1em;
-    }
-    #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
-        font-size: 14px;
-    }
-}
+  #block-ds-extras-banner-overlay {
+    top: -315px;
+    width: 250px;
+  }
 
+  #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1em;
+  }
+
+  #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 14px;
+  }
+}
 
 /* POSITION AND STYLE NEWS TITLES AND TEASERS OVER BANNER IMAGE - LOGGED IN */
 
 .logged-in #block-ds-extras-banner-overlay {
-    top: 285px;
+  top: 285px;
 }
 
 @media (max-width: 1200px) {
-    .logged-in #block-ds-extras-banner-overlay {
-        top: 325px;
-    }
+  .logged-in #block-ds-extras-banner-overlay {
+    top: 325px;
+  }
 }
 
 @media (max-width: 767px) {
-    .logged-in #block-ds-extras-banner-overlay {
-        top: -305px;
-    }
+  .logged-in #block-ds-extras-banner-overlay {
+    top: -305px;
+  }
 }
 
 @media (max-width: 485px) {
-    .logged-in #block-ds-extras-banner-overlay .field-name-title h1 {
-        font-size: 1.2em;
-    }
-    .logged-in #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
-        font-size: 15px;
-    }
+  .logged-in #block-ds-extras-banner-overlay .field-name-title h1 {
+    font-size: 1.2em;
+  }
+
+  .logged-in #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
+    font-size: 15px;
+  }
 }
 
 @media (max-width: 380px) {
-    .logged-in #block-ds-extras-banner-overlay {
-        top: -325px;
-    }
+  .logged-in #block-ds-extras-banner-overlay {
+    top: -325px;
+  }
 }
-
 
 /* STYLE NEWS FEATURED IMAGE CAPTION AND CREDITS */
 
 .page-node.node-type-stanford-news-item .content-body .field-name-field-s-image-image.field.field-type-image {
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .node-type-stanford-news-item .content-body .group-s-news-body-style {
-    margin-top: 1em;
+  margin-top: 1em;
 }
 
 .node-type-stanford-news-item .caption {
-    font-size: .7em;
-    font-style: normal;
-    line-height: 1.3em;
-    color: #928b81;
+  font-size: .7em;
+  font-style: normal;
+  line-height: 1.3em;
+  color: #928b81;
 }
 
 .node-type-stanford-news-item .caption p:after {
-    padding-right: 3px;
+  padding-right: 3px;
 }
 
 .node-type-stanford-news-item .credits {
-    margin-bottom: 0;
-    margin-top: -8px;
-    color: #928b81;
-    font-size: .7em;
-    line-height: 1.3em;
+  margin-bottom: 0;
+  margin-top: -8px;
+  color: #928b81;
+  font-size: .7em;
+  line-height: 1.3em;
 }
 
 @media (max-width: 550px) {
-    .node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
-    .node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
-        display: block;
-    }
+  .node-type-stanford-news-item .group-s-caption-style.field-group-div.caption,
+  .node-type-stanford-news-item .group-s-credits-style.field-group-div.credits {
+    display: block;
+  }
 }
-
 
 /* BODY CONTENT STYLES */
 
 .node-type-stanford-news-item .body-style {
-    width: 750px;
+  width: 750px;
 }
 
 @media (max-width: 910px) {
-    .node-type-stanford-news-item .body-style {
-        width: 100%;
-    }
+  .node-type-stanford-news-item .body-style {
+    width: 100%;
+  }
 }
 
 .node-type-stanford-news-item .body-style h2 {
-    margin: 1.3em 0 0.5em;
+  margin: 1.3em 0 0.5em;
 }
 
 /* DATE and BYLINE FOR view-mode-stanford_extras_single_region */
 
 .view-mode-stanford_extras_single_region .date-style {
-    float: left;
-    margin-bottom: 2px;
-    line-height: 1.2em;
-    font-size: 1em;
+  float: left;
+  margin-bottom: 2px;
+  line-height: 1.2em;
+  font-size: 1em;
 }
-.view-mode-stanford_extras_single_region  .byline-style {
-    font-size: 1em;
-    line-height: 1.2em;
-    clear: both;
+
+.view-mode-stanford_extras_single_region .byline-style {
+  font-size: 1em;
+  line-height: 1.2em;
+  clear: both;
 }
 
 /* HEADERS view-mode-stanford_extras_single_region */
 
 .view-mode-stanford_extras_single_region h2 {
-    font-weight: 400;
-    line-height: 1.3em;
+  font-weight: 400;
+  line-height: 1.3em;
 }
 
 /*RESPONSIVE COLUMN WIDTHS view-mode-stanford_extras_single_region  */
 
 @media (max-width: 1199px) and (min-width: 980px) {
-    .node-type-stanford-news-item .view-mode-stanford_extras_single_region .body-style {
-        width:700px;
-    }
+  .node-type-stanford-news-item .view-mode-stanford_extras_single_region .body-style {
+    width: 700px;
+  }
 }
 
 @media (max-width: 979px) and (min-width: 768px) {
-    .node-type-stanford-news-item .view-mode-stanford_extras_single_region .body-style {
-        width: 476px;
-    }
+  .node-type-stanford-news-item .view-mode-stanford_extras_single_region .body-style {
+    width: 476px;
+  }
 }

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -144,6 +144,7 @@
 .node-type-stanford-news-item .caption {
     font-size: .7em;
     font-style: normal;
+    line-height: 1.2em;
 }
 
 .node-type-stanford-news-item .caption p:after {

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -155,6 +155,7 @@
     margin-top: -8px;
     color: #928b81;
     font-size: .7em;
+    line-height: 1.2em;
 }
 
 @media (max-width: 550px) {

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -133,8 +133,8 @@
 
 /* STYLE NEWS FEATURED IMAGE CAPTION AND CREDITS */
 
-.page-node.node-type-stanford-news-item .content-body .field-name-field-s-image-image {
-    margin-bottom: 0;
+.page-node.node-type-stanford-news-item .content-body .field-name-field-s-image-image.field.field-type-image {
+    margin-bottom: 10px;
 }
 
 .node-type-stanford-news-item .content-body .group-s-news-body-style {
@@ -144,7 +144,8 @@
 .node-type-stanford-news-item .caption {
     font-size: .7em;
     font-style: normal;
-    line-height: 1.2em;
+    line-height: 1.3em;
+    color: #928b81;
 }
 
 .node-type-stanford-news-item .caption p:after {
@@ -156,7 +157,7 @@
     margin-top: -8px;
     color: #928b81;
     font-size: .7em;
-    line-height: 1.2em;
+    line-height: 1.3em;
 }
 
 @media (max-width: 550px) {

--- a/modules/stanford_news_extras/css/stanford_news_extras.css
+++ b/modules/stanford_news_extras/css/stanford_news_extras.css
@@ -31,8 +31,8 @@
 
 #block-ds-extras-banner-overlay .field-name-title h1,
 #block-ds-extras-banner-overlay .field-name-field-s-news-teaser .field-item {
-  color: white;
-  text-shadow: 0 0 4px black;
+  color: #ffffff;
+  text-shadow: 0 0 4px #000000;
 }
 
 #block-ds-extras-banner-overlay {

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -46,54 +46,54 @@ function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
   if ($form_id == "stanford_news_item_node_form") {
 
     // Don't display the credits!
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['#access'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits']['#access'] =
       FALSE;
 
     // Well, okay, if there *is* text in the credits field,
     // then let's display the credits field.
-    if (isset($form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#default_value'])) {
-      $form['field_s_image_info']['und']['0']['field_s_image_credits']['#access'] =
+    if (isset($form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['0']['value']['#default_value'])) {
+      $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits']['#access'] =
         TRUE;
     }
 
     // Update caption title.
     // Not sure which fields to target, so target all the things!
     $caption_title = t("Caption and Credits");
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#title'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_caption'][LANGUAGE_NONE]['#title'] =
       $caption_title;
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#title'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_caption'][LANGUAGE_NONE]['0']['#title'] =
       $caption_title;
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['value']['#title'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_caption'][LANGUAGE_NONE]['0']['value']['#title'] =
       $caption_title;
 
     // Caption help text.
     $caption_text = t('Use this field to display <strong>both</strong> the image caption and credits for the photographer or organization. Enter the caption, a pipe "|", and the credits.');
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_caption'][LANGUAGE_NONE]['#description'] =
       $caption_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#description'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_caption'][LANGUAGE_NONE]['0']['#description'] =
       $caption_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['0']['value']['#description'] =
       $caption_text;
 
     // Credits title.
     $credits_title =
       t("Credits ** Please use the @caption_title field ** see @caption_title field help text below.",
         array('@caption_title' => $caption_title));
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#title'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['#title'] =
       $credits_title;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#title'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['0']['#title'] =
       $credits_title;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#title'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['0']['value']['#title'] =
       $credits_title;
 
     // Credits help text.
     $credits_text = t("This field is no longer supported. Please move the text from this field into the @caption_title field.",
       array('@caption_title' => $caption_title));
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['#description'] =
       $credits_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['0']['#description'] =
       $credits_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
+    $form['field_s_image_info'][LANGUAGE_NONE]['0']['field_s_image_credits'][LANGUAGE_NONE]['0']['value']['#description'] =
       $credits_text;
   }
 }

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -37,9 +37,9 @@ function stanford_news_extras_block_view_alter(&$data, $block) {
  * - Update all the appropriate title and description fields to handle
  *   deprecation.
  *
- * @param $form
- *   The form array.
- * @param $form_id
+ * @param array $form
+ *   The form to update.
+ * @param string $form_id
  *   The form ID. Make sure we're making changes to the right form!
  */
 function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -9,13 +9,44 @@ include_once 'stanford_news_extras.features.inc';
 /**
  * Implementation of hook_form_alter()
  */
+/*
 function stanford_news_extras_form_alter(&$form, &$form_state, $form_id) {
 
   // Targeting the news item edit form
   if ($form_id == "stanford_news_item_node_form") {
     $form['title']['#description'] = t('This is the title for your news item. '
-      . 'Please keep this title under 70 characters');
+      . 'Please keep this title under 70 characters.');
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
+      t("Use this field to display both the image caption and credits for the photographer or organization. "
+        . "Enter the caption, a pipe '|', and the credits.");
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
+      t("Leave this field blank. "
+        . "Please use the caption field to display both the credits and the caption.");
+    dsm($form);
+    dsm($form_state);
   }
+}
+*/
+
+/**
+ * Implementation of hook_form_alter()
+ */
+function stanford_news_extras_form_stanford_news_item_node_form_alter(&$form, &$form_state, $form_id) {
+
+  // Targeting the news item edit form
+  if ($form_id == "stanford_news_item_node_form") {
+    $form['title']['#description'] = t('This is the title for your news item. '
+      . 'Please keep this title under 70 characters.');
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
+      t("Use this field to display both the image caption and credits for the photographer or organization. "
+        . "Enter the caption, a pipe '|', and the credits.");
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
+      t("Leave this field blank. "
+        . "Please use the caption field to display both the credits and the caption instead.");
+    dsm($form);
+    dsm($form_state);
+  }
+
 }
 
 /**

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -14,40 +14,7 @@ function stanford_news_extras_form_stanford_news_item_node_form_alter(
   &$form_state,
   $form_id) {
 
-  // Updating the help (#decription) for the news item edit form.
-  if ($form_id == "stanford_news_item_node_form") {
-
-    $form['title']['#description'] = t('This is the title for your news item. Please keep this title under 70 characters.');
-
-    // Not sure which fields to target, so target them all!
-    // Caption help text.
-    $caption_text = t('Use this field to display <strong>both</strong> the image caption and credits for the photographer or organization. Enter the caption, a pipe "|", and the credits.');
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
-      $caption_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#description'] =
-      $caption_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
-      $caption_text;
-
-    // Credits help text.
-    $credits_text = t("<strong>Leave this field blank</strong>. Please use the caption field to display both the credits and the caption instead.");
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
-      $credits_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =
-      $credits_text;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
-      $credits_text;
-
-    // Credits title.
-    $credits_title =
-      t("Credits ** Deprecated ** Include credits with the caption.");
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#title'] =
-      $credits_title;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#title'] =
-      $credits_title;
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#title'] =
-      $credits_title;
-  }
+  $form['title']['#description'] = t('This is the title for your news item. Please keep this title under 70 characters.');
 }
 
 /**
@@ -60,5 +27,61 @@ function stanford_news_extras_block_view_alter(&$data, $block) {
   }
   else if ($block->bid == 'ds_extras-banner_overlay') {
     $data['title'] = '<none>';
+  }
+}
+
+function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
+  if ($form_id == "stanford_news_item_node_form") {
+
+    // Don't display the credits!
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['#access'] =
+      FALSE;
+
+    // Well, okay, if there *is* text in the credits field,
+    // then let's display the credits field.
+    if (isset($form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#default_value'])) {
+      $form['field_s_image_info']['und']['0']['field_s_image_credits']['#access'] =
+        TRUE;
+    }
+
+    // Update caption title.
+    // Not sure which fields to target, so target all the things!
+    $caption_title = t("Caption and Credits");
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#title'] =
+      $caption_title;
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#title'] =
+      $caption_title;
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['value']['#title'] =
+      $caption_title;
+
+    // Caption help text.
+    $caption_text = t('Use this field to display <strong>both</strong> the image caption and credits for the photographer or organization. Enter the caption, a pipe "|", and the credits.');
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
+      $caption_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#description'] =
+      $caption_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
+      $caption_text;
+
+    // Credits title.
+    $credits_title =
+      t("Credits ** Please use the @caption_title field ** see @caption_title field help text below.", array('@caption_title' => $caption_title));
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#title'] =
+      $credits_title;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#title'] =
+      $credits_title;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#title'] =
+      $credits_title;
+
+    // Credits help text.
+    $credits_text = t("This field is no longer supported. Please move the text from this field into the @caption_title field.",  array('@caption_title' => $caption_title));
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
+      $credits_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =
+      $credits_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
+      $credits_text;
+
+    dsm($form);
   }
 }

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -30,6 +30,18 @@ function stanford_news_extras_block_view_alter(&$data, $block) {
   }
 }
 
+/**
+ * Handle tasks for deprecating the image credits.
+ *
+ * - Don't display the credits field unless there is text in that field.
+ * - Update all the appropriate title and description fields to handle
+ *   deprecation.
+ *
+ * @param $form
+ *   The form array.
+ * @param $form_id
+ *   The form ID. Make sure we're making changes to the right form!
+ */
 function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
   if ($form_id == "stanford_news_item_node_form") {
 
@@ -81,7 +93,5 @@ function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
       $credits_text;
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
       $credits_text;
-
-    dsm($form);
   }
 }

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -77,7 +77,8 @@ function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
 
     // Credits title.
     $credits_title =
-      t("Credits ** Please use the @caption_title field ** see @caption_title field help text below.", array('@caption_title' => $caption_title));
+      t("Credits ** Please use the @caption_title field ** see @caption_title field help text below.",
+        array('@caption_title' => $caption_title));
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#title'] =
       $credits_title;
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#title'] =
@@ -86,7 +87,8 @@ function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
       $credits_title;
 
     // Credits help text.
-    $credits_text = t("This field is no longer supported. Please move the text from this field into the @caption_title field.", array('@caption_title' => $caption_title));
+    $credits_text = t("This field is no longer supported. Please move the text from this field into the @caption_title field.",
+      array('@caption_title' => $caption_title));
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
       $credits_text;
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -25,7 +25,7 @@ function stanford_news_extras_block_view_alter(&$data, $block) {
   if ($block->bid == 'ds_extras-banner') {
     $data['title'] = '<none>';
   }
-  else if ($block->bid == 'ds_extras-banner_overlay') {
+  elseif ($block->bid == 'ds_extras-banner_overlay') {
     $data['title'] = '<none>';
   }
 }

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -14,7 +14,7 @@ function stanford_news_extras_form_stanford_news_item_node_form_alter(
   &$form_state,
   $form_id) {
 
-  // Updating the help (#decription) for the news item edit form
+  // Updating the help (#decription) for the news item edit form.
   if ($form_id == "stanford_news_item_node_form") {
 
     $form['title']['#description'] = t('This is the title for your news item. Please keep this title under 70 characters.');

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -86,7 +86,7 @@ function stanford_news_extras_deprecate_image_credits(&$form, $form_id) {
       $credits_title;
 
     // Credits help text.
-    $credits_text = t("This field is no longer supported. Please move the text from this field into the @caption_title field.",  array('@caption_title' => $caption_title));
+    $credits_text = t("This field is no longer supported. Please move the text from this field into the @caption_title field.", array('@caption_title' => $caption_title));
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
       $credits_text;
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -7,50 +7,56 @@
 include_once 'stanford_news_extras.features.inc';
 
 /**
- * Implementation of hook_form_alter()
+ * Implements hook_form_FORM_ID_alter() for stanford_news_item_node_form.
  */
-/*
-function stanford_news_extras_form_alter(&$form, &$form_state, $form_id) {
+function stanford_news_extras_form_stanford_news_item_node_form_alter(
+  &$form,
+  &$form_state,
+  $form_id)
+{
 
-  // Targeting the news item edit form
+  // Updating the help (#decription) for the news item edit form
   if ($form_id == "stanford_news_item_node_form") {
+
     $form['title']['#description'] = t('This is the title for your news item. '
       . 'Please keep this title under 70 characters.');
+
+    // Not sure which fields to target, so target them all!
+    // Caption help text.
+    $caption_text = t("Use this field to display both the image caption and " .
+      "credits for the photographer or organization. " .
+      "Enter the caption, a pipe '|', and the credits.");
     $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
-      t("Use this field to display both the image caption and credits for the photographer or organization. "
-        . "Enter the caption, a pipe '|', and the credits.");
+      $caption_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#description'] =
+      $caption_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
+      $caption_text;
+
+    // Credits help text.
+    $credits_text = t("Leave this field blank. Please use the caption field " .
+      "to display both the credits and the caption instead.");
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
-      t("Leave this field blank. "
-        . "Please use the caption field to display both the credits and the caption.");
-    dsm($form);
-    dsm($form_state);
+      $credits_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =
+      $credits_text;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#description'] =
+      $credits_text;
+
+    // Credits title.
+    $credits_title =
+      t("Credits ** Deprecated ** Include credits with the caption.");
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#title'] =
+      $credits_title;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#title'] =
+      $credits_title;
+    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['value']['#title'] =
+      $credits_title;
   }
 }
-*/
 
 /**
- * Implementation of hook_form_alter()
- */
-function stanford_news_extras_form_stanford_news_item_node_form_alter(&$form, &$form_state, $form_id) {
-
-  // Targeting the news item edit form
-  if ($form_id == "stanford_news_item_node_form") {
-    $form['title']['#description'] = t('This is the title for your news item. '
-      . 'Please keep this title under 70 characters.');
-    $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
-      t("Use this field to display both the image caption and credits for the photographer or organization. "
-        . "Enter the caption, a pipe '|', and the credits.");
-    $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
-      t("Leave this field blank. "
-        . "Please use the caption field to display both the credits and the caption instead.");
-    dsm($form);
-    dsm($form_state);
-  }
-
-}
-
-/**
- * Implementation of hook_block_view_alter()
+ * Implements hook_block_view_alter().
  */
 function stanford_news_extras_block_view_alter(&$data, $block) {
   // Remove title on blocks.

--- a/modules/stanford_news_extras/stanford_news_extras.module
+++ b/modules/stanford_news_extras/stanford_news_extras.module
@@ -12,20 +12,16 @@ include_once 'stanford_news_extras.features.inc';
 function stanford_news_extras_form_stanford_news_item_node_form_alter(
   &$form,
   &$form_state,
-  $form_id)
-{
+  $form_id) {
 
   // Updating the help (#decription) for the news item edit form
   if ($form_id == "stanford_news_item_node_form") {
 
-    $form['title']['#description'] = t('This is the title for your news item. '
-      . 'Please keep this title under 70 characters.');
+    $form['title']['#description'] = t('This is the title for your news item. Please keep this title under 70 characters.');
 
     // Not sure which fields to target, so target them all!
     // Caption help text.
-    $caption_text = t("Use this field to display both the image caption and " .
-      "credits for the photographer or organization. " .
-      "Enter the caption, a pipe '|', and the credits.");
+    $caption_text = t('Use this field to display <strong>both</strong> the image caption and credits for the photographer or organization. Enter the caption, a pipe "|", and the credits.');
     $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['#description'] =
       $caption_text;
     $form['field_s_image_info']['und']['0']['field_s_image_caption']['und']['0']['#description'] =
@@ -34,8 +30,7 @@ function stanford_news_extras_form_stanford_news_item_node_form_alter(
       $caption_text;
 
     // Credits help text.
-    $credits_text = t("Leave this field blank. Please use the caption field " .
-      "to display both the credits and the caption instead.");
+    $credits_text = t("<strong>Leave this field blank</strong>. Please use the caption field to display both the credits and the caption instead.");
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['#description'] =
       $credits_text;
     $form['field_s_image_info']['und']['0']['field_s_image_credits']['und']['0']['#description'] =


### PR DESCRIPTION
# Purpose
This PR works in conjunction with and is required by 
- https://github.com/SU-SOE/stanford_soe_helper/pull/16
- https://github.com/SU-SOE/stanford_jumpstart_engineering/pull/30

Since we want to combine caption and credits into a single field,
it works to deprecate the credits field on the news item for news extras. 
If text is in the credits field, that field is displayed. If there's no text then the credits field is not displayed. As well, it changes the title and description for both the caption and credits fields.

# Status
- Ready

# Needed By (Date)
- David said it's GTG

# Urgency
- Client is watching this, and it is for the live SoE site.

# Steps to Test

1. On an SoE dev site put credits into an image field on a news item
2. Pull this onto the site, flush cache
3. Check if the title and help text has changed for both the caption and credits field from  Step 1
4. Edit the news item and remove text from the credits field and save
5. Edit the news item and verify that the credits field *does not* appear.
6. Create a new news item. Verify that credits field *does not* appear.

# Affected Projects or Products
- This PR is dependent upon the news PR:
https://github.com/SU-SWS/stanford_news/pull/46

# Associated Issues
-  https://stanfordits.atlassian.net/browse/SOE-1594
- https://github.com/SU-SOE/stanford_soe_helper/pull/16
- https://github.com/SU-SOE/stanford_jumpstart_engineering/pull/30