### PR TITLE
Earth 157

### DIFF
--- a/config/install/core.entity_form_display.node.stanford_news.default.yml
+++ b/config/install/core.entity_form_display.node.stanford_news.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - field.field.node.stanford_news.body
+    - field.field.node.stanford_news.field_earth_matters_topic
     - field.field.node.stanford_news.field_s_news_category
     - field.field.node.stanford_news.field_s_news_date
     - field.field.node.stanford_news.field_s_news_hero_banner
@@ -33,9 +34,18 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_earth_matters_topic:
+    type: entity_reference_autocomplete
+    weight: 6
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_s_news_category:
     weight: 5
@@ -66,7 +76,7 @@ content:
     region: content
   field_s_news_rich_content:
     type: entity_reference_paragraphs
-    weight: 6
+    weight: 7
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -86,7 +96,7 @@ content:
     region: content
   path:
     type: path
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -94,17 +104,17 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 9
+    weight: 10
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -112,7 +122,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 10
+    weight: 11
     region: content
     third_party_settings: {  }
   title:
@@ -125,7 +135,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 8
     settings:
       match_operator: CONTAINS
       size: 60
@@ -134,7 +144,7 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/install/core.entity_form_display.taxonomy_term.earth_matters_topics.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.earth_matters_topics.default.yml
@@ -1,0 +1,46 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.earth_matters_topics.field_em_topics_challenge_areas
+    - taxonomy.vocabulary.earth_matters_topics
+  module:
+    - path
+    - text
+id: taxonomy_term.earth_matters_topics.default
+targetEntityType: taxonomy_term
+bundle: earth_matters_topics
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_em_topics_challenge_areas:
+    weight: 31
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.node.stanford_news.teaser.yml
+++ b/config/install/core.entity_view_display.node.stanford_news.teaser.yml
@@ -4,6 +4,12 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.stanford_news.body
+    - field.field.node.stanford_news.field_s_news_category
+    - field.field.node.stanford_news.field_s_news_date
+    - field.field.node.stanford_news.field_s_news_hero_banner
+    - field.field.node.stanford_news.field_s_news_rich_content
+    - field.field.node.stanford_news.field_s_news_source
+    - field.field.node.stanford_news.panelizer
     - node.type.stanford_news
   module:
     - text
@@ -24,4 +30,10 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  field_s_news_category: true
+  field_s_news_date: true
+  field_s_news_hero_banner: true
+  field_s_news_rich_content: true
+  field_s_news_source: true
+  panelizer: true

--- a/config/install/core.entity_view_display.taxonomy_term.earth_matters_topics.default.yml
+++ b/config/install/core.entity_view_display.taxonomy_term.earth_matters_topics.default.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.earth_matters_topics.field_em_topics_challenge_areas
+    - taxonomy.vocabulary.earth_matters_topics
+  module:
+    - text
+id: taxonomy_term.earth_matters_topics.default
+targetEntityType: taxonomy_term
+bundle: earth_matters_topics
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_em_topics_challenge_areas:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden: {  }

--- a/config/install/field.field.node.stanford_news.field_earth_matters_topic.yml
+++ b/config/install/field.field.node.stanford_news.field_earth_matters_topic.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_earth_matters_topic
+    - node.type.stanford_news
+    - taxonomy.vocabulary.earth_matters_topics
+id: node.stanford_news.field_earth_matters_topic
+field_name: field_earth_matters_topic
+entity_type: node
+bundle: stanford_news
+label: 'Earth Matters Topic'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      earth_matters_topics: earth_matters_topics
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.field.taxonomy_term.earth_matters_topics.field_em_topics_challenge_areas.yml
+++ b/config/install/field.field.taxonomy_term.earth_matters_topics.field_em_topics_challenge_areas.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_em_topics_challenge_areas
+    - taxonomy.vocabulary.earth_matters_topics
+    - taxonomy.vocabulary.research_areas
+id: taxonomy_term.earth_matters_topics.field_em_topics_challenge_areas
+field_name: field_em_topics_challenge_areas
+entity_type: taxonomy_term
+bundle: earth_matters_topics
+label: 'Challenge Areas'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      research_areas: research_areas
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/install/field.storage.node.field_earth_matters_topic.yml
+++ b/config/install/field.storage.node.field_earth_matters_topic.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_earth_matters_topic
+field_name: field_earth_matters_topic
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.taxonomy_term.field_em_topics_challenge_areas.yml
+++ b/config/install/field.storage.taxonomy_term.field_em_topics_challenge_areas.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_em_topics_challenge_areas
+field_name: field_em_topics_challenge_areas
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/taxonomy.vocabulary.earth_matters_topics.yml
+++ b/config/install/taxonomy.vocabulary.earth_matters_topics.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Earth Matters Topics'
+vid: earth_matters_topics
+description: 'List of topics covered by Earth Matters news items'
+hierarchy: 0
+weight: 0

--- a/stanford_news.info.yml
+++ b/stanford_news.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Stanford news items and views.'
 core: 8.x
 package: Stanford
-version: 8.x-1.0-dev
+version: 8.x-1.1-dev
 dependencies:
   - allowed_formats
   - datetime
@@ -20,6 +20,7 @@ dependencies:
   - scheduler
   - stanford_page
   - stanford_paragraph_hero_banner
+  - stanford_research_area
   - taxonomy
   - text
   - user


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fork stanford_news content type from SU-SWS to stanford-earth, add an "Earth Matters Topic" taxonomy vocabulary, and add a taxonomy term reference to the new taxonomy from stanford_news content type. 

# Needed By (Date)
- Next release.

# Urgency
- none

# Steps to Test

1. Change to your 'se3_blt' directory.
2. git fetch; git checkout EARTH-157
3. composer update -prefer-source
4. cd docroot/modules/stanford/stanford_news
5. git remote -v #result should show stanford-earth instead of SU-SWS
6. git fetch; git checkout EARTH-157
7. in browser, go to http://earth.local/admin/config/development/features/edit/stanford_news; import missing
8. in browser, go to http://earth.local/admin/config/development/features/diff/stanford_news; import changes
9. in browser, go to http://earth.local/admin/structure/taxonomy; should see "Earth Matters Topics" vocabulary
10. add term; enter name and pick "Challenge Area" term from "Research Areas" vocabulary
11. in browser, go to http://earth.local/node/add/stanford_news; should be an "Earth Matters Topic" reference field below the "Category" field.

# Affected versions or modules

# Associated Issues and/or People
See associated pull request for EARTH-157 in stanford-earth/se3_blt
# See Also