### PR TITLE
HSDO-1092 Fixed links in the masonry view

### DIFF
--- a/modules/stanford_news_views/stanford_news_views.views_default.inc
+++ b/modules/stanford_news_views/stanford_news_views.views_default.inc
@@ -808,6 +808,7 @@ function stanford_news_views_views_default_views() {
   $handler->display->display_options['fields']['path']['alter']['make_link'] = TRUE;
   $handler->display->display_options['fields']['path']['alter']['path'] = '[field_s_news_source]';
   $handler->display->display_options['fields']['path']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['path']['absolute'] = TRUE;
   /* Field: Content: Source */
   $handler->display->display_options['fields']['field_s_news_source']['id'] = 'field_s_news_source';
   $handler->display->display_options['fields']['field_s_news_source']['table'] = 'field_data_field_s_news_source';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- fixed the links on news/recent-news/masonry view

# Needed By (Date)
- End of sprint

# Urgency
- Low

# Steps to Test
0. Using a site whos home page domain is like `something.loc/somesite/` similar to `sites.stanford.edu/mysite/`
1. checkout this branch
2. `drush fr stanford_news_views`
3. create a news item without an external link populated
4. view the page news/recent-news/masonry
5. verify links on news items on the image and the title field go to correct location.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)