### PR TITLE
HSDO-1149 Configured path to be absolute and prevents `/sitename/sitename/` issues

### DIFF
--- a/modules/stanford_news_views/stanford_news_views.views_default.inc
+++ b/modules/stanford_news_views/stanford_news_views.views_default.inc
@@ -886,6 +886,7 @@ function stanford_news_views_views_default_views() {
   $handler->display->display_options['fields']['path']['label'] = '';
   $handler->display->display_options['fields']['path']['exclude'] = TRUE;
   $handler->display->display_options['fields']['path']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['path']['absolute'] = TRUE;
   /* Field: Content: Source */
   $handler->display->display_options['fields']['field_s_news_source']['id'] = 'field_s_news_source';
   $handler->display->display_options['fields']['field_s_news_source']['table'] = 'field_data_field_s_news_source';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Check absolute urls for path to content.

# Needed By (Date)
- End of sprint.

# Urgency
- Low

# Steps to Test

1. Checkout branch
2. `drush fr stanford_news_views -y`
3. ensure the "Use Absolute Link" is checked on the page `/admin/structure/views/nojs/config-item/stanford_news/paragraphs_news_block/field/path` under the rewrite rules.


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)