### PR TITLE
D8CORE-000: Limit options in viewfield react.

### DIFF
--- a/stanford_news.module
+++ b/stanford_news.module
@@ -182,7 +182,7 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, $field_config, &$info) {
 
   // Only alter data for the news_views view field.
-  if ($field_config->get('field_name') !== "su_news_view_field") {
+  if ($field_config->getName() !== "su_news_view_field") {
     return;
   }
 

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -180,20 +180,23 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
  * Implements hook_react_paragraphs_getfieldinfo_post_alter().
  */
 function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, $field_config,  &$info) {
+  // Only alter data for the news_views view field.
   if ($field_config->get('field_name') !== "su_news_view_field") {
     return;
   }
 
+  // We want to remove a few displays from the options.
+  // See stanford_news_field_widget_form_alter for the same appraoch.
   $deny_list = ['topics_list', 'term_block', 'vertical_teaser_term_list'];
   $vals = array_column($info['displays']['stanford_news'], 'value');
 
+  // Loop through the options and trim some.
   foreach ($deny_list as $display_name) {
     $index = array_search($display_name, $vals);
     if (is_int($index)) {
       unset($info['displays']['stanford_news'][$index]);
     }
   }
-
 }
 
 /**

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -177,6 +177,26 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 }
 
 /**
+ * Implements hook_react_paragraphs_getfieldinfo_post_alter().
+ */
+function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, $field_config,  &$info) {
+  if ($field_config->get('field_name') !== "su_news_view_field") {
+    return;
+  }
+
+  $deny_list = ['topics_list', 'term_block', 'vertical_teaser_term_list'];
+  $vals = array_column($info['displays']['stanford_news'], 'value');
+
+  foreach ($deny_list as $display_name) {
+    $index = array_search($display_name, $vals);
+    if (is_int($index)) {
+      unset($info['displays']['stanford_news'][$index]);
+    }
+  }
+
+}
+
+/**
  * Implements hook_preprocess_field_multiple_value_form().
  *
  * We look for a value that was placed there earlier by

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -179,7 +179,8 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 /**
  * Implements hook_react_paragraphs_getfieldinfo_post_alter().
  */
-function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, $field_config,  &$info) {
+function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, $field_config, &$info) {
+
   // Only alter data for the news_views view field.
   if ($field_config->get('field_name') !== "su_news_view_field") {
     return;

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -179,7 +179,7 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 /**
  * Implements hook_react_paragraphs_getfieldinfo_post_alter().
  */
-function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, $field_config, &$info) {
+function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, FieldConfigInterface $field_config, &$info) {
 
   // Only alter data for the news_views view field.
   if ($field_config->getName() !== "su_news_view_field") {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Allow altering data

# Needed By (Date)
- Today

# Urgency
- High

# Steps to Test

1. Check out https://github.com/SU-SWS/react_paragraphs/pull/44
2. Check out this branch
3. Clear all caches
4. Add a news views paragraph to a basic page
5. Ensure only [cards, list] show up as options for the display.
