### PR TITLE
added xmlsitemap and metatag configs for optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # [Stanford News](https://github.com/SU-SOE/stanford_news)
 ##### Version: 8.x-2.x
 
+[![CircleCI](https://circleci.com/gh/SU-SWS/stanford_news.svg?style=shield)](https://circleci.com/gh/SU-SWS/stanford_news)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/d22dd5e41d0a5c9198fd/test_coverage)](https://codeclimate.com/github/SU-SWS/stanford_news/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/d22dd5e41d0a5c9198fd/maintainability)](https://codeclimate.com/github/SU-SWS/stanford_news/maintainability)
+
 Maintainers: [boznik](https://github.com/boznik)
 
 Changelog: [Changelog.md](CHANGELOG.md)

--- a/config/install/core.base_field_override.node.stanford_news.promote.yml
+++ b/config/install/core.base_field_override.node.stanford_news.promote.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.stanford_news
+id: node.stanford_news.promote
+field_name: promote
+entity_type: node
+bundle: stanford_news
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/optional/metatag.metatag_defaults.node__stanford_news.yml
+++ b/config/optional/metatag.metatag_defaults.node__stanford_news.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__stanford_news
+label: 'Content: News'
+tags:
+  image_src: '[node:su_news_banner:entity:su_news_banner:0:entity:field_media_image:large]'
+  og_image: '[node:su_news_banner:entity:su_news_banner:0:entity:field_media_image:large]'
+  og_image_url: '[node:su_news_banner:entity:su_news_banner:0:entity:field_media_image:large:url]'

--- a/config/optional/metatag.metatag_defaults.page_variant__stanford_news_list-layout_builder-0.yml
+++ b/config/optional/metatag.metatag_defaults.page_variant__stanford_news_list-layout_builder-0.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: page_variant__stanford_news_list-layout_builder-0
+label: 'Page Variant: News List: Layout Builder'
+tags:
+  title: 'News | [site:name]'
+  description: 'Recent news list.'

--- a/config/optional/metatag.metatag_defaults.page_variant__stanford_news_list_terms-layout_builder-0.yml
+++ b/config/optional/metatag.metatag_defaults.page_variant__stanford_news_list_terms-layout_builder-0.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: page_variant__stanford_news_list_terms-layout_builder-0
+label: 'Page Variant: Taxonomy Term Overrides: News - Layout Builder'
+tags:
+  keywords: '[current-page:url:args]'
+  title: '[current-page:title] | [site:name]'
+  description: 'News listing page for [current-page:url:args:last]'

--- a/config/optional/xmlsitemap.settings.node.stanford_news.yml
+++ b/config/optional/xmlsitemap.settings.node.stanford_news.yml
@@ -1,0 +1,3 @@
+status: true
+priority: 0.5
+changefreq: 2419200

--- a/config/optional/xmlsitemap.settings.taxonomy_term.stanford_news_topics.yml
+++ b/config/optional/xmlsitemap.settings.taxonomy_term.stanford_news_topics.yml
@@ -1,0 +1,3 @@
+status: false
+priority: 0.5
+changefreq: 0


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added optional configs to enable metatag and xmlsitemap support if the modules are available

# Need Review By (Date)
- tomorrow

# Urgency
- medium

# Steps to Test
1. nothing to test.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
