### PR TITLE
D8CORE-000: Fixes broken filtering logic on view field.

### DIFF
--- a/stanford_news.module
+++ b/stanford_news.module
@@ -183,7 +183,7 @@ function stanford_news_react_paragraphs_getfieldinfo_post_alter(array &$info, ar
 
   // Only alter data for the news_views view field.
   if ($field_config->getName() !== "su_news_view_field") {
-    return $info;
+    return;
   }
 
   // We want to remove a few displays from the options.
@@ -199,7 +199,6 @@ function stanford_news_react_paragraphs_getfieldinfo_post_alter(array &$info, ar
     }
   }
   sort($info['displays']['stanford_news']);
-  return $info;
 }
 
 /**

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -179,7 +179,7 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 /**
  * Implements hook_react_paragraphs_form_field_data_alter().
  */
-function stanford_news_react_paragraphs_form_field_data_alter(array &$info, array $field_element, FieldConfig $field_config) {
+function stanford_news_react_paragraphs_form_field_data_alter(array &$info, array $field_element, FieldConfigInterface $field_config) {
 
   // Only alter data for the news_views view field.
   if ($field_config->getName() !== "su_news_view_field") {

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -179,7 +179,7 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 /**
  * Implements hook_react_paragraphs_getfieldinfo_post_alter().
  */
-function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, FieldConfigInterface $field_config, $info) {
+function stanford_news_react_paragraphs_getfieldinfo_post_alter(array &$info, array $field_element, FieldConfig $field_config) {
 
   // Only alter data for the news_views view field.
   if ($field_config->getName() !== "su_news_view_field") {

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -177,9 +177,9 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 }
 
 /**
- * Implements hook_react_paragraphs_getfieldinfo_post_alter().
+ * Implements hook_react_paragraphs_form_field_data_alter().
  */
-function stanford_news_react_paragraphs_getfieldinfo_post_alter(array &$info, array $field_element, FieldConfig $field_config) {
+function stanford_news_react_paragraphs_form_field_data_alter(array &$info, array $field_element, FieldConfig $field_config) {
 
   // Only alter data for the news_views view field.
   if ($field_config->getName() !== "su_news_view_field") {

--- a/stanford_news.module
+++ b/stanford_news.module
@@ -179,11 +179,11 @@ function stanford_news_field_widget_form_alter(&$element, FormStateInterface $fo
 /**
  * Implements hook_react_paragraphs_getfieldinfo_post_alter().
  */
-function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, FieldConfigInterface $field_config, &$info) {
+function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, FieldConfigInterface $field_config, $info) {
 
   // Only alter data for the news_views view field.
   if ($field_config->getName() !== "su_news_view_field") {
-    return;
+    return $info;
   }
 
   // We want to remove a few displays from the options.
@@ -198,6 +198,8 @@ function stanford_news_react_paragraphs_getfieldinfo_post_alter($field_element, 
       unset($info['displays']['stanford_news'][$index]);
     }
   }
+  sort($info['displays']['stanford_news']);
+  return $info;
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Makes the display filtering with the alter hook actually work. 

# Needed By (Date)
- Today

# Urgency
- Hight

# Steps to Test

1. Check out this branch
2. Check out branch https://github.com/SU-SWS/react_paragraphs/pull/45
3. Clear all caches
4. Create a new basic page
5. Add news view paragraph and see only two options (Card + List)

# Affected Projects or Products
- D8CORE
