### PR TITLE
D8CORE-1958: changing a span to a div for validation fix

### DIFF
--- a/templates/sections/news-byline-social.html.twig
+++ b/templates/sections/news-byline-social.html.twig
@@ -11,11 +11,11 @@
     {% if content.su_news_publishing_date or content.su_news_byline %}
       <div {{ region_attributes.su_news_byline.addClass('news-date-pipe-byline') }}>
         {%- if content.su_news_publishing_date|render|striptags("<drupal-render-placeholder>")|trim is not empty %}
-          <span class="su_news_publishing_date-region">{{ content.su_news_publishing_date }}</span>
+          <div class="su_news_publishing_date-region">{{ content.su_news_publishing_date }}</div>
         {% endif %}
         {% if content.su_news_publishing_date|render|striptags("<drupal-render-placeholder>")|trim and content.su_news_byline|render|striptags("<drupal-render-placeholder>")|trim  %} | {% endif %}
         {%- if content.su_news_byline|render|striptags("<drupal-render-placeholder>")|trim is not empty %}
-          <span class="su_news_byline-region">{{ content.su_news_byline }}</span>
+          <div class="su_news_byline-region">{{ content.su_news_byline }}</div>
         {% endif %}
       </div>
     {% endif %}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Changed a span tag to a div for html validation reason.

# Needed By (Date)
- Friday

# Urgency
- Medium

# Steps to Test

1. Pull in this change
2.  Look at a news article.
3. Verify the byline doesn't have a span wrapping divs. eg: <span class="su_news_publishing_date-region"> should be <div class="su_news_publishing_date-region">

# Affected Projects or Products
- News Accelerant on both SOE and Cardinal.

# Associated Issues and/or People
- D8CORE-1958

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
