### PR TITLE
D8CORE-2178, D8CORE-2180, D8CORE-2181: Event updates

### DIFF
--- a/config/install/core.entity_form_display.node.stanford_news.default.yml
+++ b/config/install/core.entity_form_display.node.stanford_news.default.yml
@@ -120,7 +120,7 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
       default_paragraph_type: stanford_wysiwyg
@@ -194,3 +194,4 @@ hidden:
   promote: true
   sticky: true
   title: true
+

--- a/config/install/field.field.node.stanford_news.su_news_publishing_date.yml
+++ b/config/install/field.field.node.stanford_news.su_news_publishing_date.yml
@@ -14,7 +14,11 @@ label: 'Publishing Date'
 description: '<em>The “publishing date” will appear next to the “byline” below the headline and dek on the article page.</em>'
 required: false
 translatable: false
-default_value: {  }
+default_value:
+  -
+    default_date_type: now
+    default_date: now
 default_value_callback: ''
 settings: {  }
 field_type: datetime
+

--- a/config/install/field.field.node.stanford_news.su_news_topics.yml
+++ b/config/install/field.field.node.stanford_news.su_news_topics.yml
@@ -10,7 +10,7 @@ field_name: su_news_topics
 entity_type: node
 bundle: stanford_news
 label: 'News Topics Terms'
-description: 'Add all topic terms for your article here. Note, the top 3 topic terms in this list will be displayed on the list page teaser and at the top of the article page. The complete list of terms will be displayed at the end of the article page. You can rearrange the list using the drag-drop functionality'
+description: 'Add all topic terms for your article here. Note, the top 3 topic terms in this list will be displayed on the list page teaser and at the top of the article page. The complete list of terms will be displayed at the end of the article page. You can rearrange the list using the drag-drop functionality. <a href="https://userguide.sites.stanford.edu/tour/news/how-add-edit-and-delete-news-topics-taxonomy" target="_blank">How to add, edit and delete news topics terms.</a>'
 required: false
 translatable: false
 default_value: {  }
@@ -26,3 +26,4 @@ settings:
     auto_create: false
     auto_create_bundle: ''
 field_type: entity_reference
+

--- a/config/install/views.view.stanford_news.yml
+++ b/config/install/views.view.stanford_news.yml
@@ -615,6 +615,19 @@ display:
           entity_field: type
           plugin_id: bundle
       sorts:
+        su_news_publishing_date_value:
+          id: su_news_publishing_date_value
+          table: node__su_news_publishing_date
+          field: su_news_publishing_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+          plugin_id: datetime
         created:
           id: created
           table: node_field_data
@@ -2009,3 +2022,4 @@ display:
         - 'config:field.storage.node.su_news_publishing_date'
         - 'config:field.storage.node.su_news_source'
         - 'config:field.storage.node.su_news_topics'
+


### PR DESCRIPTION
# READY FOR REVIEW 

SEE: https://github.com/SU-SWS/stanford_profile/pull/243

# Summary
- 2178: Set paragraphs to collapsed by default
- 2180: Add help text to topics field that links to userguide page
- 2181: Alter the view sorting so that it sorts on published date rather than authored date

# Needed By (Date)
- June 30th

# Urgency
- Medium 

# Steps to Test

1. Check out this branch
2. Import config (drush cim)
3. Go to create a new news node and see default date on publishing date is today 
4. On new news node form see new help text on topic field that links to userguide page
5. Fill out the fields and save the news node
6. Create one or more news nodes with different dates
7. Navigate to /news and validate that the sorting is in the correct order

# Affected Projects or Products
- D8CORE
- SOE

# Associated Issues and/or People
- https://github.com/SU-SWS/stanford_profile/pull/243
- D8CORE-2178
- D8CORE-2180
- D8CORE-2181
- @cynmij 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
