### PR TITLE
D8CORE-2132: adding a wrapper div to address issue with SOE subtheme

### DIFF
--- a/templates/components/news-vertical-teaser/news-vertical-teaser.twig
+++ b/templates/components/news-vertical-teaser/news-vertical-teaser.twig
@@ -47,9 +47,11 @@
       {{- news_vertical_teaser_image -}}
     </div>
   </figure>
-  <h2 class="su-link su-card__link {{ news_url_link_type }}">
-    {{- news_vertical_teaser_headline -}}
-  </h2>
+  <div class="su-news-header">
+    <h2 class="su-link su-card__link {{ news_url_link_type }}">
+      {{- news_vertical_teaser_headline -}}
+    </h2>
+  </div>
   {%- if news_url is not empty -%}
     </a>
   {%- endif -%}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Adding a wrapper div for the news vertical teaser.

# Needed By (Date)
- Wednesday

# Urgency
- Med

# Steps to Test

1. Pull in this and the two other branches - SOE Profile and Subtheme
2. Build
3. Verify on a news node that the vertical cards have the blue border bottom on the link and it looks correct.

# Affected Projects or Products
- SOE Subtheme and News 

# Associated Issues and/or People
- D8CORE-2132
- https://github.com/SU-SOE/soe_profile/pull/58
- https://github.com/SU-SOE/soe_basic/pull/15


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
