### PR TITLE
D8CORE-5568 Fix news list template when no date is available

### DIFF
--- a/templates/components/news-list/news-item-list.twig
+++ b/templates/components/news-list/news-item-list.twig
@@ -78,9 +78,12 @@
 
     {# News List Date #}
     {%- block block_news_list_date %}
-      {% if news_list_publishing_date|render|striptags('<drupal-render-placeholder>')|trim is not empty %}
-        <p class="su-news-list__item-date">{{ news_list_publishing_date|render_clean }}</p>
-      {% endif -%}
+      {# Since CSS Grid is used, always render an element even if it's empty. #}
+      <div class="su-news-list__item-date">
+        {% if news_list_publishing_date|render|striptags('<drupal-render-placeholder>')|trim is not empty %}
+          <p>{{ news_list_publishing_date|render_clean }}</p>
+        {% endif -%}
+      </div>
     {% endblock -%}
 
     </header>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Fix markup since CSS grid expects elements to exist.

# Need Review By (Date)
- 3/16

# Urgency
- high

# Steps to Test
1. checkout this branch
2. clear caches
3. create a news item
   - Delete the "published date" field
   - add an image to the "Featured Image" field
4. view the `/news` page
5. verify the image for your piece of content is to the right of the new title, not above it.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
